### PR TITLE
feat: Docker Compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+e2e
+test-results
+showcase-artifacts
+.env*
+!.env.local.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# --- deps ---
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# --- build ---
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# --- runner ---
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=build /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 8080
+ENV PORT=8080
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    env_file: .env.local
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'standalone',
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile` (deps → build → runner) on `node:22-alpine` with non-root user
- `docker-compose.yml` exposing port 8080 (Cloud Run compatible) with wget healthcheck
- `.dockerignore` to keep image lean
- `next.config.mjs` updated with `output: 'standalone'`

## Test plan
- [x] `docker compose up -d --build` — image builds successfully
- [x] `curl http://localhost:8080` — returns 307 (auth redirect, expected)
- [x] `docker compose down` — clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)