### PR TITLE
Fix dark mode theme awareness for modals, selects, and invoice inputs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,7 @@
 
   /* Dark theme */
   [data-theme="dark"] {
+    color-scheme: dark;
     --background: 222 20% 10%;
     --foreground: 210 20% 90%;
     --card: 222 18% 14%;

--- a/src/components/invoice-form.tsx
+++ b/src/components/invoice-form.tsx
@@ -232,7 +232,7 @@ export function InvoiceForm({ clients, defaultClientId, invoice }: InvoiceFormPr
             step="0.01"
             value={taxRate}
             onChange={(e) => setTaxRate(parseFloat(e.target.value) || 0)}
-            className="w-20 rounded-lg border border-border bg-card px-2.5 py-1.5 text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-ring/20 focus:border-ring"
+            className="w-20 rounded-lg border border-border bg-card px-2.5 py-1.5 text-sm text-foreground text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-ring/20 focus:border-ring"
           />
         </div>
         <div className="flex justify-between w-48 text-sm">

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -29,7 +29,7 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
       ref={dialogRef}
       onClose={onClose}
       className={cn(
-        'rounded-2xl shadow-modal p-0 w-full max-w-lg border border-border animate-scale-in backdrop:bg-transparent',
+        'rounded-2xl shadow-modal p-0 w-full max-w-lg border border-border bg-card text-card-foreground animate-scale-in backdrop:bg-transparent',
         className
       )}
     >

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -20,7 +20,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           id={id}
           className={cn(
-            "flex h-9 w-full rounded-lg border bg-card px-3 py-2 text-sm text-foreground shadow-soft transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:border-ring appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%236B7280%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat pr-10",
+            "flex h-9 w-full rounded-lg border bg-card px-3 py-2 text-sm text-foreground shadow-soft transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:border-ring appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat pr-10",
             error
               ? 'border-destructive focus-visible:ring-destructive/20 focus-visible:border-destructive'
               : 'border-input hover:border-input/80',

--- a/src/tests/components/invoice-form.test.tsx
+++ b/src/tests/components/invoice-form.test.tsx
@@ -87,6 +87,14 @@ describe('InvoiceForm', () => {
     expect(screen.getByRole('button', { name: 'Create Invoice' })).toBeInTheDocument();
   });
 
+  it('applies theme-aware text color to tax rate input', () => {
+    render(<InvoiceForm clients={clients} />);
+    const taxInput = screen.getAllByRole('spinbutton').find(
+      (el) => el.closest('.flex.items-center.gap-4')
+    );
+    expect(taxInput?.className).toContain('text-foreground');
+  });
+
   it('updates line item total when values change', async () => {
     render(<InvoiceForm clients={clients} />);
     const numberInputs = screen.getAllByRole('spinbutton');

--- a/src/tests/components/modal.test.tsx
+++ b/src/tests/components/modal.test.tsx
@@ -56,4 +56,15 @@ describe('Modal', () => {
     );
     expect(screen.getByLabelText('Close')).toBeInTheDocument();
   });
+
+  it('applies theme-aware background and text colors', () => {
+    render(
+      <Modal open={true} onClose={() => {}} title="Test">
+        Content
+      </Modal>
+    );
+    const dialog = document.querySelector('dialog')!;
+    expect(dialog.className).toContain('bg-card');
+    expect(dialog.className).toContain('text-card-foreground');
+  });
 });

--- a/src/tests/components/select.test.tsx
+++ b/src/tests/components/select.test.tsx
@@ -43,4 +43,10 @@ describe('Select', () => {
     expect(firstOption.value).toBe('');
     expect(firstOption.textContent).toBe('Select...');
   });
+
+  it('uses currentColor for dropdown arrow to support dark mode', () => {
+    render(<Select id="test" options={options} />);
+    const select = screen.getByRole('combobox');
+    expect(select.className).toContain('currentColor');
+  });
 });


### PR DESCRIPTION
## Summary
- Add `bg-card text-card-foreground` to modal `<dialog>` so it adapts to dark theme
- Add `color-scheme: dark` to dark theme CSS so native inputs (date pickers, select dropdowns) render with dark colors
- Switch select component's dropdown arrow SVG from hardcoded gray to `currentColor`
- Add `text-foreground` to invoice form tax rate input

## Test plan
- [x] Modal test: verify `bg-card` and `text-card-foreground` classes present
- [x] Select test: verify dropdown arrow uses `currentColor`
- [x] Invoice form test: verify tax rate input has `text-foreground`
- [ ] Manual: toggle dark mode and verify edit client modal, new/edit invoice inputs are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)